### PR TITLE
Copy SQL Server foreign keys during database migration

### DIFF
--- a/CopyDatabase.MsSQLServer/Requests/SqlServer/SqlServerDatabaseCopyExecutor.cs
+++ b/CopyDatabase.MsSQLServer/Requests/SqlServer/SqlServerDatabaseCopyExecutor.cs
@@ -44,6 +44,7 @@ internal sealed class SqlServerDatabaseCopyExecutor : IDatabaseCopyExecutor
         string destinationDatabaseConnection = BuildConnection(request.DestinationCredentials, destinationDatabaseName);
 
         var tables = await catalog.LoadTablesAsync(sourceConnection, cancellationToken);
+        var foreignKeys = await catalog.LoadScriptedObjectsAsync(sourceConnection, SqlServerSql.ForeignKeys, cancellationToken);
         var views = await catalog.LoadScriptedObjectsAsync(sourceConnection, SqlServerSql.Views, cancellationToken);
         var routines = await catalog.LoadScriptedObjectsAsync(sourceConnection, SqlServerSql.Routines, cancellationToken);
 
@@ -66,7 +67,7 @@ internal sealed class SqlServerDatabaseCopyExecutor : IDatabaseCopyExecutor
         {
             if (request.CopySchema)
             {
-                await schemaCopier.CopyAsync(request, sourceConnection, destinationConnection, transaction, tables, routines, views, cancellationToken);
+                await schemaCopier.CopyAsync(request, sourceConnection, destinationConnection, transaction, tables, foreignKeys, routines, views, cancellationToken);
             }
 
             if (request.CopyData)

--- a/CopyDatabase.MsSQLServer/Requests/SqlServer/SqlServerSchemaCopier.cs
+++ b/CopyDatabase.MsSQLServer/Requests/SqlServer/SqlServerSchemaCopier.cs
@@ -21,12 +21,14 @@ internal sealed class SqlServerSchemaCopier
         SqlConnection destinationConnection,
         SqlTransaction transaction,
         IReadOnlyCollection<SqlServerSchemaObject> tables,
+        IReadOnlyCollection<SqlServerSchemaObject> foreignKeys,
         IReadOnlyCollection<SqlServerSchemaObject> routines,
         IReadOnlyCollection<SqlServerSchemaObject> views,
         CancellationToken cancellationToken)
     {
         await catalog.EnsureSchemasCreatedAsync(destinationConnection, transaction, tables.Select(oo => oo.Schema), cancellationToken);
         await CopyTableSchemasAsync(request, sourceConnectionString, destinationConnection, transaction, tables, cancellationToken);
+        await CopyScriptedObjectsAsync(request, destinationConnection, transaction, foreignKeys, "foreign key", cancellationToken, "F");
         await CopyScriptedObjectsAsync(request, destinationConnection, transaction, routines, "routine", cancellationToken);
         await CopyScriptedObjectsAsync(request, destinationConnection, transaction, views, "view", cancellationToken);
     }
@@ -63,13 +65,14 @@ internal sealed class SqlServerSchemaCopier
         SqlTransaction transaction,
         IReadOnlyCollection<SqlServerSchemaObject> objects,
         string objectType,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? sqlObjectType = null)
     {
         int counter = 1;
         foreach (var item in objects)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (await catalog.ObjectExistsAsync(connection, transaction, item, cancellationToken))
+            if (await catalog.ObjectExistsAsync(connection, transaction, item, cancellationToken, sqlObjectType))
             {
                 SqlServerCopyProgress.Report(request, $"Skipping existing {objectType} {counter} of {objects.Count} ({item.QualifiedName})");
                 counter++;

--- a/CopyDatabase.MsSQLServer/Requests/SqlServer/SqlServerSql.cs
+++ b/CopyDatabase.MsSQLServer/Requests/SqlServer/SqlServerSql.cs
@@ -27,6 +27,59 @@ FROM INFORMATION_SCHEMA.ROUTINES r
 INNER JOIN sys.sql_modules m ON m.object_id = OBJECT_ID(r.SPECIFIC_SCHEMA + '.' + r.SPECIFIC_NAME)
 ORDER BY r.SPECIFIC_SCHEMA, r.SPECIFIC_NAME;";
 
+    public const string ForeignKeys = @"
+SELECT
+    SCHEMA_NAME(fk.schema_id),
+    fk.name,
+    'ALTER TABLE ' + QUOTENAME(OBJECT_SCHEMA_NAME(fk.parent_object_id)) + '.' + QUOTENAME(OBJECT_NAME(fk.parent_object_id)) +
+    ' WITH CHECK ADD CONSTRAINT ' + QUOTENAME(fk.name) +
+    ' FOREIGN KEY (' +
+        STUFF((
+            SELECT ', ' + QUOTENAME(parent_column.name)
+            FROM sys.foreign_key_columns foreign_key_column
+            INNER JOIN sys.columns parent_column
+                ON parent_column.object_id = foreign_key_column.parent_object_id
+               AND parent_column.column_id = foreign_key_column.parent_column_id
+            WHERE foreign_key_column.constraint_object_id = fk.object_id
+            ORDER BY foreign_key_column.constraint_column_id
+            FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 2, '') +
+    ') REFERENCES ' + QUOTENAME(OBJECT_SCHEMA_NAME(fk.referenced_object_id)) + '.' + QUOTENAME(OBJECT_NAME(fk.referenced_object_id)) +
+    ' (' +
+        STUFF((
+            SELECT ', ' + QUOTENAME(referenced_column.name)
+            FROM sys.foreign_key_columns foreign_key_column
+            INNER JOIN sys.columns referenced_column
+                ON referenced_column.object_id = foreign_key_column.referenced_object_id
+               AND referenced_column.column_id = foreign_key_column.referenced_column_id
+            WHERE foreign_key_column.constraint_object_id = fk.object_id
+            ORDER BY foreign_key_column.constraint_column_id
+            FOR XML PATH(''), TYPE).value('.', 'NVARCHAR(MAX)'), 1, 2, '') +
+    ')' +
+    CASE fk.delete_referential_action
+        WHEN 1 THEN ' ON DELETE CASCADE'
+        WHEN 2 THEN ' ON DELETE SET NULL'
+        WHEN 3 THEN ' ON DELETE SET DEFAULT'
+        ELSE ''
+    END +
+    CASE fk.update_referential_action
+        WHEN 1 THEN ' ON UPDATE CASCADE'
+        WHEN 2 THEN ' ON UPDATE SET NULL'
+        WHEN 3 THEN ' ON UPDATE SET DEFAULT'
+        ELSE ''
+    END +
+    CASE WHEN fk.is_not_for_replication = 1 THEN ' NOT FOR REPLICATION' ELSE '' END +
+    ';' + CHAR(13) +
+    'ALTER TABLE ' + QUOTENAME(OBJECT_SCHEMA_NAME(fk.parent_object_id)) + '.' + QUOTENAME(OBJECT_NAME(fk.parent_object_id)) +
+    ' CHECK CONSTRAINT ' + QUOTENAME(fk.name) + ';'
+FROM sys.foreign_keys fk
+INNER JOIN sys.tables parent_table ON parent_table.object_id = fk.parent_object_id
+INNER JOIN sys.tables referenced_table ON referenced_table.object_id = fk.referenced_object_id
+WHERE parent_table.is_ms_shipped = 0
+  AND referenced_table.is_ms_shipped = 0
+  AND parent_table.name NOT IN ('sysdiagrams')
+  AND referenced_table.name NOT IN ('sysdiagrams')
+ORDER BY SCHEMA_NAME(fk.schema_id), fk.name;";
+
     public const string CreateTableScript = @"
 DECLARE @table_name SYSNAME
 SELECT @table_name = '{Schema}.{Name}'

--- a/UnitTests/CopyDatabase.MsSQLServer.Tests/Requests/CopyDatabaseDockerIntegrationTests.cs
+++ b/UnitTests/CopyDatabase.MsSQLServer.Tests/Requests/CopyDatabaseDockerIntegrationTests.cs
@@ -74,6 +74,43 @@ public sealed class CopyDatabaseDockerIntegrationTests
         Assert.Contains(progressMessages, oo => oo.ObjectType == "Table" && oo.ObjectName == "dbo.CopyDatabaseUiTable" && oo.Message.Contains("rows copied"));
     }
 
+    [Fact]
+    public async Task CopyDatabaseRequest_CopiesForeignKeysThatReferenceTablesInSameDatabase()
+    {
+        if (Environment.GetEnvironmentVariable("COPYDATABASE_DOCKER_SQL_TESTS") != "1") return;
+
+        await ResetSourceFixture();
+        await DropDestinationDatabases();
+
+        var executor = new SqlServerDatabaseCopyExecutor();
+
+        await executor.CopyAsync(new CopyDatabaseRequest
+        {
+            SourceCredentials = CreateCredentials("127.0.0.1,14333"),
+            DestinationCredentials = CreateCredentials("127.0.0.1,14334"),
+            DatabaseName = SourceDatabaseName,
+            DestinationDatabaseName = DestinationDatabaseName,
+            CopySchema = true,
+            CopyData = true,
+            DropDestinationDatabase = true
+        }, TestContext.Current.CancellationToken);
+
+        await using var connection = new SqlConnection(BuildConnection("127.0.0.1,14334", DestinationDatabaseName));
+        await connection.OpenAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, await Scalar<int>(connection, "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND TABLE_NAME = 'AReferenced'"));
+        Assert.Equal(1, await Scalar<int>(connection, "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'dbo' AND TABLE_NAME = 'BReferencing'"));
+        Assert.Equal(1, await Scalar<int>(connection, "SELECT COUNT(*) FROM dbo.AReferenced"));
+        Assert.Equal(1, await Scalar<int>(connection, "SELECT COUNT(*) FROM dbo.BReferencing"));
+        Assert.Equal(1, await Scalar<int>(connection, """
+            SELECT COUNT(*)
+            FROM sys.foreign_keys
+            WHERE name = 'FK_BReferencing_AReferenced'
+              AND parent_object_id = OBJECT_ID(N'dbo.BReferencing')
+              AND referenced_object_id = OBJECT_ID(N'dbo.AReferenced');
+            """));
+    }
+
     private static DatabaseServerTestCredentials CreateCredentials(string dataSource)
     {
         return new DatabaseServerTestCredentials
@@ -96,9 +133,23 @@ public sealed class CopyDatabaseDockerIntegrationTests
 
         await Execute(sourceConnection, """
             IF OBJECT_ID('dbo.CopyDatabaseUiView','V') IS NOT NULL DROP VIEW dbo.CopyDatabaseUiView;
+            IF OBJECT_ID('dbo.BReferencing','U') IS NOT NULL DROP TABLE dbo.BReferencing;
+            IF OBJECT_ID('dbo.AReferenced','U') IS NOT NULL DROP TABLE dbo.AReferenced;
             IF OBJECT_ID('dbo.CopyDatabaseUiTable','U') IS NOT NULL DROP TABLE dbo.CopyDatabaseUiTable;
             CREATE TABLE dbo.CopyDatabaseUiTable (Id int NOT NULL PRIMARY KEY, Name nvarchar(40) NOT NULL);
             INSERT INTO dbo.CopyDatabaseUiTable (Id, Name) VALUES (1, N'Alpha'), (2, N'Beta');
+            CREATE TABLE dbo.AReferenced (Id int NOT NULL PRIMARY KEY, Name nvarchar(40) NOT NULL);
+            CREATE TABLE dbo.BReferencing
+            (
+                Id int NOT NULL PRIMARY KEY,
+                AReferencedId int NOT NULL,
+                Name nvarchar(40) NOT NULL,
+                CONSTRAINT FK_BReferencing_AReferenced
+                    FOREIGN KEY (AReferencedId)
+                    REFERENCES dbo.AReferenced(Id)
+            );
+            INSERT INTO dbo.AReferenced (Id, Name) VALUES (1, N'Parent');
+            INSERT INTO dbo.BReferencing (Id, AReferencedId, Name) VALUES (10, 1, N'Child');
             """);
         await Execute(sourceConnection, "EXEC('CREATE VIEW dbo.CopyDatabaseUiView AS SELECT Id, Name FROM dbo.CopyDatabaseUiTable');");
     }


### PR DESCRIPTION
## Summary
- Adds SQL Server foreign-key scripting to the provider split so copied databases preserve same-database FK constraints.
- Applies FK scripts after all tables are created, before routines and views, to avoid dependency-order failures.
- Adds a Docker-backed regression test for a table pair where the referenced table sorts before the referencing table.

## Testing
- `dotnet build CopyDatabase.sln --no-restore /m:1 /nr:false` ✅
- `dotnet test CopyDatabase.sln --no-build /m:1 /nr:false` ✅
- `COPYDATABASE_DOCKER_SQL_TESTS=1 dotnet test UnitTests\CopyDatabase.MsSQLServer.Tests\CopyDatabase.MsSQLServer.Tests.csproj --filter FullyQualifiedName~CopyDatabaseDockerIntegrationTests /m:1 /nr:false` ✅